### PR TITLE
[143-b] - Enable ts-check, start of a pattern for type checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Sets `box` to the axis aligned root bounding box of the tile set in the [group](
 ### .getOrientedBounds
 
 ```js
-getOrientedBounds( box : Box3, boxTransform : Matrix4) : boolean;
+getOrientedBounds( box : Box3, boxTransform : Matrix4 ) : boolean;
 ```
 
 Sets `box` and `boxTransform` to the bounds and matrix that describe the oriented bounding box that encapsulates the root of the tile set. Returns `false` if the tile root was not loaded.
@@ -457,7 +457,7 @@ Fires the callback for every loaded scene in the hierarchy with the associatd ti
 ### .onLoadTileSet
 
 ```js
-onLoadTileSet = null : ( tileSet : Object ) => void
+onLoadTileSet = null : ( tileSet : Tileset ) => void
 ```
 
 Callback that is called whenever a tile set is loaded.
@@ -465,7 +465,7 @@ Callback that is called whenever a tile set is loaded.
 ### .onLoadModel
 
 ```js
-onLoadModel = null : ( scene : Object3D, tile : object ) => void
+onLoadModel = null : ( scene : Object3D, tile : Tile ) => void
 ```
 
 Callback that is called every time a model is loaded. This can be used in conjunction with [.forEachLoadedModel](#forEachLoadedModel) to set the material of all load and still yet to load meshes in the tile set.
@@ -473,7 +473,7 @@ Callback that is called every time a model is loaded. This can be used in conjun
 ### .onDisposeModel
 
 ```js
-onDisposeModel = null : ( scene : Object3D, tile : object ) => void
+onDisposeModel = null : ( scene : Object3D, tile : Tile ) => void
 ```
 
 Callback that is called every time a model is disposed of. This should be used in conjunction with [.onLoadModel](#onLoadModel) to dispose of any custom materials created for a tile. Note that the textures, materials, and geometries that a tile loaded in with are all automatically disposed of even if they have been removed from the tile meshes.

--- a/src/base/Tile.d.ts
+++ b/src/base/Tile.d.ts
@@ -1,6 +1,7 @@
 
 /**
  * 3d-tiles Tile object per spec:
+ * (incomplete, expanding as features become supported.)
  * - https://github.com/CesiumGS/3d-tiles/blob/master/specification/schema/tile.schema.json
  */
 export interface TileBase {
@@ -14,6 +15,7 @@ export interface TileBase {
     }
     geometricError : number,
     refine? : 'REPLACE' | 'ADD';
+	extras? : Record<string, any>;
 }
 
 /** Documented 3d-tile state managed by the TilesRenderer* / traverseFunctions! */

--- a/src/base/Tile.d.ts
+++ b/src/base/Tile.d.ts
@@ -1,0 +1,90 @@
+
+/**
+ * 3d-tiles Tile object per spec:
+ * - https://github.com/CesiumGS/3d-tiles/blob/master/specification/schema/tile.schema.json
+ */
+export interface TileBase {
+    boundingVolume : { box: number[] },
+    children : TileBase[];
+    content : {
+        uri? : string;
+        boundingVolume : { box: number[] },
+        // noted as only existing in the code to support old pre-1.0 tilesets
+        url? : string;
+    }
+    geometricError : number,
+    refine? : 'REPLACE' | 'ADD';
+}
+
+/** Documented 3d-tile state managed by the TilesRenderer* / traverseFunctions! */
+export interface Tile extends TileBase {
+
+    parent : Tile;
+	/**
+	 * Hierarchy Depth from the TileGroup
+	 */
+	__depth : number;
+	/**
+	 * The screen space error for this tile
+	 */
+	__error : number;
+	/**
+	 * How far is this tiles bounds from the nearest active Camera.
+	 * Expected to be filled in during calculateError implementations.
+	 */
+	 __distanceFromCamera : number;
+	/**
+	 * This tile is currently active if:
+	 *  1: Tile content is loaded and ready to be made visible if needed
+	 */
+	__active : boolean;
+	/**
+	 * This tile is currently visible if:
+	 *  1: Tile content is loaded
+	 *  2: Tile is within a camera frustum
+	 *  3: Tile meets the SSE requirements
+	 */
+	 __visible : boolean;
+	/**
+	 * Frame number that this tile was last used: active+visible
+	 */
+	 __lastFrameVisited : number;
+	/**
+	 * TODO: Document this if it is useful enough to be the default property in the LRU sorting.
+	 */
+	 __depthFromRenderedParent : number;
+
+}
+
+/** Internal state used/set by the package. */
+export interface TileInternal extends Tile {
+
+	// tile description
+	__externalTileSet : boolean;
+	__contentEmpty : boolean;
+	__isLeaf : boolean;
+
+	// resource tracking
+	__usedLastFrame : boolean;
+	__used : boolean;
+	
+	// Visibility tracking
+	__allChildrenLoaded : boolean;
+	__childrenWereVisible : boolean;
+	__inFrustum : boolean;
+	__wasSetVisible : boolean;
+
+	// download state tracking
+
+	/**
+	 * This tile is currently active if:
+	 *  1: Tile content is loaded and ready to be made visible if needed
+	 */
+	__active : boolean;
+	__loadIndex : number;
+	__loadAbort : AbortController | null;
+	/** TODO: enum for -> UNLOADED, LOADING, PARSING, LOADED, FAILED from constants.js */
+	__loadingState : number;
+	__wasSetActive : boolean;
+
+}

--- a/src/base/TilesRendererBase.d.ts
+++ b/src/base/TilesRendererBase.d.ts
@@ -1,3 +1,4 @@
+import { Tile, TileInternal } from '../base/Tile';
 import { LRUCache } from '../utilities/LRUCache';
 import { PriorityQueue } from '../utilities/PriorityQueue';
 
@@ -6,66 +7,27 @@ export class TilesRendererBase {
 	readonly rootTileset : Object | null;
 	readonly root : Object | null;
 
-	errorTarget : Number;
-	errorThreshold : Number;
-	loadSiblings : Boolean;
-	displayActiveTiles : Boolean;
-	maxDepth : Number;
-	stopAtEmptyTiles : Boolean;
+	errorTarget : number;
+	errorThreshold : number;
+	loadSiblings : boolean;
+	displayActiveTiles : boolean;
+	maxDepth : number;
+	stopAtEmptyTiles : boolean;
 
 	fetchOptions : Object;
 	/** function to preprocess the url for each individual tile */
 	preprocessURL : ((uri: string | URL) => string) | null;
 
-	lruCache : LRUCache;
-	parseQueue : PriorityQueue;
-	downloadQueue : PriorityQueue;
+	lruCache : LRUCache<TileInternal>;
+	parseQueue : PriorityQueue<TileInternal>;
+	downloadQueue : PriorityQueue<TileInternal>;
 
 	constructor( url : String );
 	update() : void;
 	traverse(
-		beforeCb : ( ( tile : Object, parent : Object, depth : Number ) => Boolean ) | null,
-		afterCb : ( ( tile : Object, parent : Object, depth : Number ) => Boolean ) | null
+		beforeCb : ( ( tile : TileInternal, parent : TileInternal, depth : number ) => boolean ) | null,
+		afterCb : ( ( tile : TileInternal, parent : TileInternal, depth : number ) => boolean ) | null
 	) : void;
 	dispose() : void;
-
-}
-
-/** Documented 3d-tile state managed by the TilesRenderer* / traverseFunctions! */
-export interface Tile {
-
-	/**
-	 * Hierarchy Depth from the TileGroup
-	 */
-	__depth : Number;
-	/**
-	 * The screen space error for this tile
-	 */
-	__error : Number;
-	/**
-	 * How far is this tiles bounds from the nearest active Camera.
-	 * Expected to be filled in during calculateError implementations.
-	 */
-	 __distanceFromCamera : Number;
-	/**
-	 * This tile is currently active if:
-	 *  1: Tile content is loaded and ready to be made visible if needed
-	 */
-	__active : Boolean;
-	/**
-	 * This tile is currently visible if:
-	 *  1: Tile content is loaded
-	 *  2: Tile is within a camera frustum
-	 *  3: Tile meets the SSE requirements
-	 */
-	 __visible : Boolean;
-	/**
-	 * Frame number that this tile was last used: active+visible
-	 */
-	 __lastFrameVisited : Number;
-	/**
-	 * TODO: Document this if it is useful enough to be the default property in the LRU sorting.
-	 */
-	 __depthFromRenderedParent : Number;
 
 }

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import path from 'path';
 import { urlJoin } from '../utilities/urlJoin.js';
 import { LRUCache } from '../utilities/LRUCache.js';
@@ -8,8 +10,8 @@ import { UNLOADED, LOADING, PARSING, LOADED, FAILED } from './constants.js';
 /**
  * Function for provided to sort all tiles for prioritizing loading/unloading.
  *
- * @param {Tile} a
- * @param {Tile} b
+ * @param {import('./Tile').Tile} a
+ * @param {import('./Tile').Tile} b
  * @returns number
  */
 const priorityCallback = ( a, b ) => {
@@ -36,7 +38,7 @@ const priorityCallback = ( a, b ) => {
 
 /**
  * Function for sorting the evicted LRU items. We should evict the shallowest depth first.
- * @param {Tile} tile
+ * @param {import('./Tile').Tile} tile
  * @returns number
  */
 const lruPriorityCallback = ( tile ) => {
@@ -48,8 +50,19 @@ const lruPriorityCallback = ( tile ) => {
 
 };
 
+/**
+ * @type {import('./TilesRendererBase').TilesRendererBase}
+ * Base class for common rendering engine agnostic portions of the TilesRenderer
+ */
 export class TilesRendererBase {
 
+	/**
+	 * The tileset at rootUrl or null if it is not loaded yet.
+	 *
+	 * @readonly
+	 * @memberof TilesRendererBase
+	 * @returns {null | import('./Tileset').Tileset} rootTileSet
+	 */
 	get rootTileSet() {
 
 		const tileSet = this.tileSets[ this.rootURL ];
@@ -65,6 +78,13 @@ export class TilesRendererBase {
 
 	}
 
+	/**
+	 * The root tile null if it is not loaded yet.
+	 *
+	 * @readonly
+	 * @memberof TilesRendererBase
+	 * @returns {null | import('./Tile').Tile} rootTileSet
+	 */
 	get root() {
 
 		const tileSet = this.rootTileSet;
@@ -172,6 +192,13 @@ export class TilesRendererBase {
 
 	}
 
+	/**
+	 * Base preprocess step for each tile
+	 *
+	 * @param {import('./Tile').TileInternal} tile
+	 * @param {import('./Tile').TileInternal} parentTile
+	 * @param {string} tileSetDir
+	 */
 	preprocessNode( tile, parentTile, tileSetDir ) {
 
 		if ( tile.content ) {
@@ -284,6 +311,13 @@ export class TilesRendererBase {
 	}
 
 	// Private Functions
+	/**
+	 *
+	 * @param {string} url
+	 * @param {RequestInit} fetchOptions
+	 * @param {null | import('./Tile').Tile} parent
+	 * @returns {Promise<import('./Tileset').Tileset>} Tileset promise
+	 */
 	fetchTileSet( url, fetchOptions, parent = null ) {
 
 		return fetch( url, fetchOptions )
@@ -360,6 +394,11 @@ export class TilesRendererBase {
 
 	}
 
+	/**
+	 * Base loading for each tile
+	 *
+	 * @param {import('./Tile').TileInternal} tile
+	 */
 	requestTileContents( tile ) {
 
 		// If the tile is already being loaded then don't

--- a/src/base/Tileset.d.ts
+++ b/src/base/Tileset.d.ts
@@ -1,0 +1,11 @@
+import { Tile } from './Tile';
+
+export interface Tileset {
+
+    asset: Object;
+
+    geometricError: Number;
+
+    root: Tile;
+
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,6 +16,8 @@ import { PNTSLoader } from './three/PNTSLoader';
 import { CMPTLoader } from './three/CMPTLoader';
 
 import { TilesRendererBase } from './base/TilesRendererBase';
+import { Tile, TileInternal } from './base/Tile';
+import { Tileset } from './base/Tileset';
 import { B3DMLoaderBase } from './base/B3DMLoaderBase';
 import { I3DMLoaderBase } from './base/I3DMLoaderBase';
 import { PNTSLoaderBase } from './base/PNTSLoaderBase';
@@ -29,6 +31,8 @@ export {
 	TilesRenderer,
 	B3DMLoader,
 
+	Tile,
+	Tileset,
 	TilesRendererBase,
 	B3DMLoaderBase,
 

--- a/src/utilities/LRUCache.d.ts
+++ b/src/utilities/LRUCache.d.ts
@@ -1,18 +1,18 @@
-export class LRUCache {
+export class LRUCache<T> {
 
-	maxSize : Number;
-	minSize : Number;
-	unloadPercent : Number;
-	unloadPriorityCallback : ( item : any ) => Number;
+	maxSize : number;
+	minSize : number;
+	unloadPercent : number;
+	unloadPriorityCallback : ( item : T ) => number;
 
-	isFull() : Boolean;
-	add( item : any, callback : ( item : any ) => Number ) : Boolean;
-	remove( item : any ) : Boolean;
+	isFull() : boolean;
+	add( item : T, callback : ( item : T ) => void ) : void;
+	remove( item : T ) : boolean;
 
-	markUsed( item : any ) : void;
+	markUsed( item : T ) : void;
 	markAllUnused() : void;
 
 	unloadUnusedContent() : void;
-	scheduleUnload( markAllUnused : Boolean );
+	scheduleUnload( markAllUnused? : boolean );
 
 }

--- a/src/utilities/PriorityQueue.d.ts
+++ b/src/utilities/PriorityQueue.d.ts
@@ -1,11 +1,11 @@
-export class PriorityQueue {
+export class PriorityQueue<T> {
 
-	maxJobs : Number;
-	autoUpdate : Boolean;
-	priorityCallback : ( itemA : any , itemB : any ) => Number;
+	maxJobs : number;
+	autoUpdate : boolean;
+	priorityCallback : ( itemA : T , itemB : T ) => number;
 
 	sort() : void;
-	add( item : any, callback : ( item : any ) => any ) : Promise< any >;
+	add( item : T, callback : ( item : T ) => any ) : Promise< Response >;
 	remove( item : any ) : void;
 
 	tryRunJobs() : void;


### PR DESCRIPTION
- Add a generic type to LRUCache / PriorityQueue which enables some type safety of dev time in the TilesRendererBase.js file.
- Add more detailed Tile types
  - TileBase: intended to be the baseline type of the object from the 3d-tiles spec
  - Tile: Intention here was that this would be the type exposed for the PriorityQueue, and these would be considered the 'documented' values as used by the priority functions which the end-user can replace.
  - TileInternal: Provide some documentation of what the internally used tile properties are for developers to work with, not intended for real publishing, but after turning on the `// @ts-check` in the TilesRendererBase, this ended up being the type needed for the typescript checking to function?!

- TilesRendererBase.js
  - Add jsdoc type import, and `// @ts-check` magic comment.. the import type comments are pretty cumbersome, but I feel like they'll help the maintaining experience over time? I thought there was a better way to reference existing .d.ts files, but I'm not finding it offhand yet?!