### PR TITLE
Feature/extension system

### DIFF
--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -346,9 +346,7 @@ export class TilesRendererBase {
 				.then( json => {
 
 					tileSets[ url ] = json;
-					extensions.setExtensionsUsed( json.extensionsUsed || [] );
-					extensions.setExtensionsRequired( json.extensionsRequired || [] );
-					extensions.checkSupport();
+					extensions.useTileset( json );
 
 				} );
 

--- a/src/extensions/3DTILES_content_gltf.d.ts
+++ b/src/extensions/3DTILES_content_gltf.d.ts
@@ -1,5 +1,5 @@
 import { LoadingManager } from 'three';
-import { ExtensionBase } from './index.js';
+import { ExtensionBase } from './index';
 
 export class GLTFExtension extends ExtensionBase {
 

--- a/src/extensions/3DTILES_content_gltf.d.ts
+++ b/src/extensions/3DTILES_content_gltf.d.ts
@@ -1,0 +1,8 @@
+import { LoadingManager } from 'three';
+import { ExtensionBase } from './index.js';
+
+export class GLTFExtension extends ExtensionBase {
+
+	constructor( manager: LoadingManager );
+
+}

--- a/src/extensions/3DTILES_content_gltf.js
+++ b/src/extensions/3DTILES_content_gltf.js
@@ -1,0 +1,50 @@
+import { ExtensionBase, ExtensionType } from './index.js';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { DefaultLoadingManager } from 'three';
+
+export class GLTFExtension extends ExtensionBase {
+
+	constructor( manager = DefaultLoadingManager ) {
+
+		super( ExtensionType.TILE, '3DTILES_content_gltf' );
+		this.manager = manager;
+		this.parse = this.parse.bind( this );
+
+	}
+
+	parse( _thereIsNoExtData, buffer, fileExtension ) {
+
+		if ( [ 'glb', 'gltf' ].indexOf( fileExtension ) === - 1 ) return null;
+
+		// TODO(extensions): there's no trivial way to tell whether a GLTFLoader instance supports an extension
+		// if there was, we could notify the dev?
+		// const requiredGltfExtensions = this.data.extensionsRequired;
+		const manager = this.manager;
+
+		return new Promise( ( resolve, reject ) => {
+
+			let loader = manager.getHandler( 'path.gltf' ) || manager.getHandler( 'path.glb' );
+
+			if ( ! loader ) {
+
+				loader = new GLTFLoader( manager );
+				loader.crossOrigin = this.crossOrigin;
+				loader.withCredentials = this.withCredentials;
+
+			}
+
+			// assume any pre-registered loader has paths configured as the user desires, but if we're making
+			// a new loader, use the working path during parse to support relative uris on other hosts
+			const resourcePath = loader.resourcePath || loader.path || this.workingPath;
+
+			loader.parse( buffer, resourcePath, model => {
+
+				resolve( model.scene );
+
+			}, reject );
+
+		} );
+
+	}
+
+}

--- a/src/extensions/ExtensionBase.js
+++ b/src/extensions/ExtensionBase.js
@@ -1,0 +1,31 @@
+import { isValidExtensionType } from './utilities.js';
+
+export class ExtensionBase {
+
+	constructor( extType, name ) {
+
+		// the key used to look up into the extension objects
+		this.name = name;
+
+		// enforce a 3d-tiles spec supported extensions blob, which we know how to extract
+		this.extensionType = extType;
+		if ( ! isValidExtensionType( extType ) ) throw Error( `Unsupported Extension Type: ${extType}` );
+
+		// if the extension is used after a root tileset has been loaded
+		// this should have any root level data associated with the extension.name
+		// ex: for the `3DTILES_content_gltf` extension, it should include the extensionsUsed/Required to load the gltf files
+		// referenced in the tileset.
+		// - "3DTILES_content_gltf": { "extensionsUsed": ["EXT_mesh_gpu_instancing"], "extensionsRequired": ["EXT_mesh_gpu_instancing"] }
+		// see extension specs @ https://github.com/CesiumGS/3d-tiles/tree/main/extensions for what you might find in the .data object.
+		this.data = {};
+
+	}
+
+	setTileset( tileset ) {
+
+		// initialize the base data from the top level for this extension if available
+		this.data = tileset && tileset.extensions && tileset.extensions[ this.name ] || {};
+
+	}
+
+}

--- a/src/extensions/ExtensionBase.js
+++ b/src/extensions/ExtensionBase.js
@@ -2,14 +2,21 @@ import { isValidExtensionType } from './utilities.js';
 
 export class ExtensionBase {
 
-	constructor( extType, name ) {
+	constructor( extType, extName ) {
 
 		// the key used to look up into the extension objects
-		this.name = name;
+		this.name = extName;
+
+		this.extensionType = extType;
 
 		// enforce a 3d-tiles spec supported extensions blob, which we know how to extract
-		this.extensionType = extType;
 		if ( ! isValidExtensionType( extType ) ) throw Error( `Unsupported Extension Type: ${extType}` );
+
+		this.data = {};
+
+	}
+
+	useTileset( tileset ) {
 
 		// if the extension is used after a root tileset has been loaded
 		// this should have any root level data associated with the extension.name
@@ -17,14 +24,10 @@ export class ExtensionBase {
 		// referenced in the tileset.
 		// - "3DTILES_content_gltf": { "extensionsUsed": ["EXT_mesh_gpu_instancing"], "extensionsRequired": ["EXT_mesh_gpu_instancing"] }
 		// see extension specs @ https://github.com/CesiumGS/3d-tiles/tree/main/extensions for what you might find in the .data object.
-		this.data = {};
-
-	}
-
-	setTileset( tileset ) {
 
 		// initialize the base data from the top level for this extension if available
 		this.data = tileset && tileset.extensions && tileset.extensions[ this.name ] || {};
+		return this;
 
 	}
 

--- a/src/extensions/ExtensionSystem.js
+++ b/src/extensions/ExtensionSystem.js
@@ -1,0 +1,221 @@
+import { ExtensionBase, ExtensionType } from './index.js';
+
+/**
+ * Map of functions which extract the data required for each type of extension
+ * - TBD: may need info from multiple places?
+ */
+const ExtractTypeData = Object.freeze( {
+	[ ExtensionType.ASSET ]: ( tileset ) => tileset && tileset[ ExtensionType.ASSET ] && tileset[ ExtensionType.ASSET ].extensions || null,
+	[ ExtensionType.CONTENT ]: ( tileOrTileset ) => tileOrTileset && tileOrTileset[ ExtensionType.CONTENT ] && tileOrTileset[ ExtensionType.CONTENT ].extensions || null,
+	[ ExtensionType.TILE ]: ( tile ) => tile && tile.extensions || null,
+	[ ExtensionType.TILESET ]: ( tileset ) => tileset && tileset.extensions || null,
+} );
+
+const DEFAULT_SUPPORTED_EXTENSIONS = [ '3DTILES_content_gltf' ];
+
+/** Adjust in index.d.ts:FunctionName also */
+const SUPPORTED_FUNCTIONS = [ 'parse', 'fetch' ];
+
+/**
+ * Manage extensions to the 3d-tiles system.
+ *
+ * Modeled very loosely after the GLTFLoader extension system in threejs
+ */
+export class ExtensionSystem {
+
+	constructor( tilesRenderer ) {
+
+		this.tilesRenderer = tilesRenderer;
+		// Map<ExtensionType, ExtensionBase[]>
+		this.extensions = new Map();
+		// Map<FuncName, ExtensionBase[]>
+		this.functions = new Map();
+
+		this.extensionsRegistered = new Set( DEFAULT_SUPPORTED_EXTENSIONS.slice() );
+		this.extensionsUsed = new Set();
+		this.extensionsRequired = new Set();
+
+	}
+
+	// At tileset parse, flag any extensions that are used
+	setExtensionsUsed( used ) {
+
+		this.extensionsUsed.add( ...used );
+
+	}
+
+	setExtensionsRequired( required ) {
+
+		this.extensionsRequired.add( ...required );
+
+	}
+
+	// notify of unsupported extensions
+	checkSupport( extensionName = undefined ) {
+
+		if ( extensionName ) {
+
+			return this.extensionsRegistered.has( extensionName );
+
+		}
+
+		for ( const ext of this.extensionsUsed.values() ) {
+
+			if ( this.extensionsRegistered.has( ext ) ) {
+
+				console.log( `Optional extension ${ext} was not registered` );
+
+			}
+
+		}
+
+		for ( const ext of this.extensionsRequired.values() ) {
+
+			if ( this.extensionsRegistered.has( ext ) ) {
+
+				console.error( `Required extension ${ext} was not registered` );
+
+			}
+
+		}
+
+	}
+
+	/**
+	 * Iterate through any extensions registered for this type/function,
+	 * and return first Truthy result
+	 */
+	useFunction( funcName, obj, ...args ) {
+
+		const extensions = this.functions.get( funcName );
+		if ( ! extensions || extensions.length === 0 ) return null;
+
+		for ( let i = 0; i < extensions.length; i ++ ) {
+
+			const extension = extensions[ i ]();
+			// TODO(extensions): do we need different type data per function at all?! this gives us
+			// root level data + data from the .type registered at extension creation time
+			// which I *think* should be enough for now?
+			// unless different functions implemented within a single extension need to reference
+			// different data types.. in which case we'll need more info !
+			extension.setTileset( this.tilesRenderer.rootTileset );
+			const data = getExtensionSpecificData( extension.name, getExtensionTypeData( extension.type, obj ) );
+			const func = getFunction( extension, funcName );
+			if ( func ) {
+
+				// data can be null.. ex: 3DTILES_content_gltf has top level data
+				// but not per-tile data
+				const result = func( data, ...args );
+				if ( result ) return result;
+
+			}
+
+		}
+
+		return null;
+
+	}
+
+	/**
+	 * Registering the extension as a factory function allows the user to specify
+	 * wheter each extension is a singleton or should create 1 extension
+	 * instance per invocation.
+	 *
+	 * @param callback: ( tilesRenderer: TilesRenderer ) => T extends ExtensionBase
+	 */
+	register( callback ) {
+
+		// create an instance so that we can register by implemented function
+		const ext = callback();
+		for ( const fname of SUPPORTED_FUNCTIONS ) {
+
+			if ( fname in ext ) {
+
+				const functionCallbacks = this.functions.get( fname ) || [];
+				if ( functionCallbacks.indexOf( callback ) === - 1 ) {
+
+					functionCallbacks.push( callback );
+
+				}
+				this.functions.set( fname, functionCallbacks );
+
+			}
+
+		}
+
+		// track as registered
+		this.extensionsRegistered.add( ext.name );
+		return this;
+
+	}
+
+	unregister( type, callback ) {
+
+		// TODO(extensions): implement unregister once we narrow down the
+		// ways they need to be tracked.
+		throw new Error( 'unregister not implemented yet' );
+
+	}
+
+}
+
+/** Return valid function if one exists as part of a valid ExtensionBase or null. */
+function getFunction( extension, fn ) {
+
+	const functionAllowed = (
+		// 1: extensions must extend ExtensionBase
+		extension instanceof ExtensionBase &&
+		extension.extensionType in ExtractTypeData &&
+		// 2: we must know how to extract base 3d-tiles data for that extension
+		ExtractTypeData[ extension.extensionType ] &&
+		// 3: object containing valid function names if restricted
+		SUPPORTED_FUNCTIONS.indexOf( fn ) !== - 1
+	);
+
+	// 4: and the function is implemented by the extension
+	const implementation = (
+		fn in extension &&
+		extension[ fn ]
+	);
+
+	if ( functionAllowed && implementation ) {
+
+		return implementation;
+
+	}
+
+	if ( ! functionAllowed && implementation ) {
+
+		// noisy for dev time, notify if not allowed but is implemented ?!
+		console.warn( `Attempting to use unsupported function in extension`, extension.name, fn );
+
+	}
+
+	return null;
+
+}
+
+function getExtensionTypeData( extensionType, obj ) {
+
+	const extract = (
+		extensionType in ExtractTypeData &&
+		ExtractTypeData[ extensionType ] ||
+		null
+	);
+
+	const extensionData = extract && extract( obj );
+	return extensionData || null;
+
+}
+
+/** Return a valid extension data object if one exists, null if not */
+function getExtensionSpecificData( extensionName, extensionTypeData ) {
+
+	if ( extensionTypeData ) {
+
+		return extensionTypeData[ extensionName ] || null;
+
+	}
+	return null;
+
+}

--- a/src/extensions/ExtensionSystem.js
+++ b/src/extensions/ExtensionSystem.js
@@ -129,12 +129,12 @@ export class ExtensionSystem {
 
 			const extension = callback();
 			// TODO(extensions): do we need different type data per function at all?! this gives us
-			// root level data + data from the .type registered at extension creation time
+			// root level data + data from the .extensionType registered at extension creation time
 			// which I *think* should be enough for now?
 			// unless different functions implemented within a single extension need to reference
 			// different data types.. in which case we'll need more info !
 			extension.useTileset( tileset );
-			const data = getExtensionSpecificData( extension.name, getExtensionTypeData( extension.type, obj ) );
+			const data = getExtensionSpecificData( extension.name, getExtensionTypeData( extension.extensionType, obj ) );
 			const func = getFunction( extension, funcName );
 			if ( func ) {
 

--- a/src/extensions/ExtensionSystem.js
+++ b/src/extensions/ExtensionSystem.js
@@ -136,10 +136,16 @@ export class ExtensionSystem {
 			extension.useTileset( tileset );
 			const data = getExtensionSpecificData( extension.name, getExtensionTypeData( extension.extensionType, obj ) );
 			const func = getFunction( extension, funcName );
-			if ( func ) {
 
-				// data can be null.. ex: 3DTILES_content_gltf has top level data
-				// but not per-tile data
+			// TODO(extensions): Is there a better way to narrow execution scope?
+			// Maybe?: TILE/CONTENT/ASSET type require data vs TILESET type doesn't?
+			// ex: 3DTILES_content_gltf has top level data but not per-tile data
+			// as do some of the metadata extensions which might apply styling from top level ext data
+			// to the tile?
+
+			// or just delegate getting the data to the extension implementation?
+			if ( func && data ) {
+
 				const result = func( data, ...args );
 				if ( result ) return result;
 

--- a/src/extensions/ExtensionType.js
+++ b/src/extensions/ExtensionType.js
@@ -1,0 +1,28 @@
+
+const ASSET = 'asset';
+const CONTENT = 'content';
+const TILE = 'tile';
+const TILESET = 'tileset';
+
+/** Available extension types */
+export const ExtensionType = Object.freeze( {
+
+	/**
+	 * Asset extensions: usage tbd?
+	 * @ref: https://github.com/CesiumGS/3d-tiles/blob/main/specification/schema/asset.schema.json#L21
+	 */
+	ASSET: ASSET,
+	/**
+  	 * spefically run during content download / parse, passed any info in content.extensions
+  	 * @ref: https://github.com/CesiumGS/3d-tiles/blob/main/specification/schema/content.schema.json#L21
+	 */
+	CONTENT: CONTENT,
+	/* @ref: https://github.com/CesiumGS/3d-tiles/blob/main/specification/schema/tile.schema.json#L80 */
+	TILE: TILE,
+	/**
+	 * Hooks before/after tileset loading, any data placed in tileset.extensions is available to all extensions
+	 * @ref: https://github.com/CesiumGS/3d-tiles/blob/main/specification/schema/tileset.schema.json#L51
+	 */
+	TILESET: TILESET,
+
+} );

--- a/src/extensions/index.d.ts
+++ b/src/extensions/index.d.ts
@@ -1,4 +1,3 @@
-import { TilesRendererBase } from '..';
 import { Tile } from '../base/Tile';
 import { Tileset } from '../base/Tileset';
 
@@ -8,17 +7,38 @@ export enum ExtensionType {
     TILESET = 'tileset',
     TILE = 'tile',
 }
+export const ExtensionNameGLTF = '3DTILES_content_gltf';
 
 /** A Tile, or a Tileset object to extract extension data out of */
 type ExtensionInput = Tile | Tileset;
 type ExtensionFactoryFn = () => ExtensionBase;
+type Registration = { renew: () => void, cancel: () => void, active: () => boolean, callback: ExtensionFactoryFn };
 export class ExtensionSystem {
+    /** resource tracking extension creation funcs by used function */
+    extensionsByFunc: Map<string, Set<ExtensionFactoryFn>>;
 
-    constructor( tilesRenderer: TilesRendererBase );
-    register( callback: ExtensionFactoryFn ): ExtensionSystem;
-    unregister( callback: ExtensionFactoryFn ): ExtensionSystem;
+    /** resource tracking extension creation funcs by used ExtensionName */
+    extensionsByName: Map<string, Set<ExtensionFactoryFn>>;
+
+    constructor( );
+
+    /** register a callback which creates an extension which extends ExtensionBase */
+    register( callback: ExtensionFactoryFn ): Registration;
+
+    /** Select tileset, track any requirements for tileset */
+    useTileset( tileset: Tileset|null ): void;
+
+    /** Does system support an extension? */
+    has( extensionName: string ): boolean;
+
+    /** Does any used tileset require an extension? */
+    requires( extensionName: string ): boolean;
+
+    /** check all extensions seen in the tileset against registered extensions and log out missing items */
+    checkSupport( ): void;
+
+    /** usage in tiles-renderer package */
     useFunction( funcName: FunctionName, obj: ExtensionInput, ...args: any[]): any|null;
-    checkSupport( extensionName?: string ): boolean;
 }
 
 /** Available functions to use */
@@ -27,12 +47,24 @@ type FunctionName = 'parse' | 'fetch';
 /** each extension combines a specific type of data, with a set of optional function implementations */
 export abstract class ExtensionBase {
 
-    constructor( type: ExtensionType, name: string );
-
-    // Do these need to be here at all? They help solidify the expected return values
-    parse?( extensionData: Record<string, any>, ...args: any[] ): Promise<any> | null;
-    fetch?( extensionData: Record<string, any>, ...args: any[] ): Promise<TilesFetchResponse> | null;
+    constructor( extensionType: ExtensionType, extensionName: string );
+    name: Readonly<string>;
+    type: Readonly<ExtensionType>;
+    useTileset( tileset?: Tileset ): ExtensionBase;
 
 }
 
 interface TilesFetchResponse { ok: boolean, arrayBuffer:() => null|ArrayBuffer }
+
+/**
+ * Typing for available functions that the extender of ExtensionBase may override
+ *
+ * Do these need to be here at all? They help solidify the expected return values
+ * Might make sense once `...args: any[]` is expanded to legit function sigs?
+ */
+interface ExtensionFunctionInterface {
+
+    parse?( extensionData: Record<string, any>, ...args: any[] ): Promise<any> | null;
+    fetch?( extensionData: Record<string, any>, ...args: any[] ): Promise<TilesFetchResponse> | null;
+
+}

--- a/src/extensions/index.d.ts
+++ b/src/extensions/index.d.ts
@@ -50,6 +50,7 @@ export abstract class ExtensionBase {
     constructor( extensionType: ExtensionType, extensionName: string );
     name: Readonly<string>;
     type: Readonly<ExtensionType>;
+    data: Record<string, any>;
     useTileset( tileset?: Tileset ): ExtensionBase;
 
 }

--- a/src/extensions/index.d.ts
+++ b/src/extensions/index.d.ts
@@ -1,0 +1,38 @@
+import { TilesRendererBase } from '..';
+import { Tile } from '../base/Tile';
+import { Tileset } from '../base/Tileset';
+
+export enum ExtensionType {
+    CONTENT = 'content',
+    ASSET = 'asset',
+    TILESET = 'tileset',
+    TILE = 'tile',
+}
+
+/** A Tile, or a Tileset object to extract extension data out of */
+type ExtensionInput = Tile | Tileset;
+type ExtensionFactoryFn = () => ExtensionBase;
+export class ExtensionSystem {
+
+    constructor( tilesRenderer: TilesRendererBase );
+    register( callback: ExtensionFactoryFn ): ExtensionSystem;
+    unregister( callback: ExtensionFactoryFn ): ExtensionSystem;
+    useFunction( funcName: FunctionName, obj: ExtensionInput, ...args: any[]): any|null;
+    checkSupport( extensionName?: string ): boolean;
+}
+
+/** Available functions to use */
+type FunctionName = 'parse' | 'fetch';
+
+/** each extension combines a specific type of data, with a set of optional function implementations */
+export abstract class ExtensionBase {
+
+    constructor( type: ExtensionType, name: string );
+
+    // Do these need to be here at all? They help solidify the expected return values
+    parse?( extensionData: Record<string, any>, ...args: any[] ): Promise<any> | null;
+    fetch?( extensionData: Record<string, any>, ...args: any[] ): Promise<TilesFetchResponse> | null;
+
+}
+
+interface TilesFetchResponse { ok: boolean, arrayBuffer:() => null|ArrayBuffer }

--- a/src/extensions/index.js
+++ b/src/extensions/index.js
@@ -1,4 +1,3 @@
 export { ExtensionSystem } from './ExtensionSystem.js';
 export { ExtensionBase } from './ExtensionBase.js';
 export { ExtensionType } from './ExtensionType.js';
-

--- a/src/extensions/index.js
+++ b/src/extensions/index.js
@@ -1,0 +1,4 @@
+export { ExtensionSystem } from './ExtensionSystem.js';
+export { ExtensionBase } from './ExtensionBase.js';
+export { ExtensionType } from './ExtensionType.js';
+

--- a/src/extensions/utilities.js
+++ b/src/extensions/utilities.js
@@ -1,0 +1,8 @@
+import { ExtensionType } from './ExtensionType.js';
+
+export function isValidExtensionType( extType ) {
+
+	const types = Object.values( ExtensionType );
+	return types.indexOf( extType ) !== - 1;
+
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -34,3 +34,5 @@ export * as ThreeTileUtils from './three/ThreeTileUtils';
 
 export { LRUCache } from './utilities/LRUCache';
 export { PriorityQueue } from './utilities/PriorityQueue';
+
+export { ExtensionBase, ExtensionType } from './extensions';

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ import { isTileDownloadFinished } from './base/traverseFunctions.js';
 
 import { LRUCache } from './utilities/LRUCache.js';
 import { PriorityQueue } from './utilities/PriorityQueue.js';
+import { ExtensionBase, ExtensionType } from './extensions/index.js';
 
 export {
 	DebugTilesRenderer,
@@ -62,4 +63,7 @@ export {
 	RANDOM_COLOR,
 	RANDOM_NODE_COLOR,
 	CUSTOM_COLOR,
+
+	ExtensionBase,
+	ExtensionType,
 };

--- a/src/three/GLTFExtensionLoader.d.ts
+++ b/src/three/GLTFExtensionLoader.d.ts
@@ -1,8 +1,9 @@
 
 import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { LoaderBase } from '../base/LoaderBase';
 import { LoadingManager } from 'three';
 
-export class GLTFExtensionLoader {
+export class GLTFExtensionLoader extends LoaderBase {
 
 	constructor( manager : LoadingManager );
 	parse( buffer : ArrayBuffer ) : Promise< GLTF >;

--- a/src/three/GLTFExtensionLoader.js
+++ b/src/three/GLTFExtensionLoader.js
@@ -16,13 +16,30 @@ export class GLTFExtensionLoader extends LoaderBase {
 		return new Promise( ( resolve, reject ) => {
 
 			const manager = this.manager;
+			const fetchOptions = this.fetchOptions;
 			let loader = manager.getHandler( 'path.gltf' ) || manager.getHandler( 'path.glb' );
 
 			if ( ! loader ) {
 
 				loader = new GLTFLoader( manager );
-				loader.crossOrigin = this.crossOrigin;
-				loader.withCredentials = this.withCredentials;
+				if ( fetchOptions.credentials === 'include' && fetchOptions.mode === 'cors' ) {
+
+					loader.setCrossOrigin( 'use-credentials' );
+
+				}
+
+				if ( 'credentials' in fetchOptions ) {
+
+					loader.setWithCredentials( fetchOptions.credentials === 'include' );
+
+				}
+
+				if ( fetchOptions.headers ) {
+
+					loader.setRequestHeader( fetchOptions.headers );
+
+				}
+
 
 			}
 

--- a/src/three/TilesRenderer.d.ts
+++ b/src/three/TilesRenderer.d.ts
@@ -2,6 +2,7 @@ import { Box3, Camera, Vector2, Matrix4, WebGLRenderer, Object3D, LoadingManager
 import { Tile } from '../base/Tile';
 import { Tileset } from '../base/Tileset';
 import { TilesRendererBase } from '../base/TilesRendererBase';
+import { ExtensionSystem } from '../extensions';
 import { TilesGroup } from './TilesGroup';
 
 export class TilesRenderer extends TilesRendererBase {
@@ -12,6 +13,7 @@ export class TilesRenderer extends TilesRendererBase {
 	manager : LoadingManager;
 
 	group : TilesGroup;
+	extensions : ExtensionSystem;
 
 	getBoundsTransform( target: Matrix4 ) : Boolean;
 

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -474,77 +474,84 @@ export class TilesRenderer extends TilesRendererBase {
 		const fetchOptions = this.fetchOptions;
 
 		const manager = this.manager;
+		const extensions = this.extensions;
+
 		const loadIndex = tile._loadIndex;
+
 		let promise = null;
+		promise = extensions.useFunction( 'parse', tile, buffer, extension );
 
-		switch ( extension ) {
+		if ( ! promise ) {
 
-			case 'b3dm': {
+			switch ( extension ) {
 
-				const loader = new B3DMLoader( manager );
-				loader.workingPath = workingPath;
-				loader.fetchOptions = fetchOptions;
-				promise = loader
-					.parse( buffer )
-					.then( res => res.scene );
-				break;
+				case 'b3dm': {
+
+					const loader = new B3DMLoader( manager );
+					loader.workingPath = workingPath;
+					loader.fetchOptions = fetchOptions;
+					promise = loader
+						.parse( buffer )
+						.then( res => res.scene );
+					break;
+
+				}
+
+				case 'pnts': {
+
+					const loader = new PNTSLoader( manager );
+					loader.workingPath = workingPath;
+					loader.fetchOptions = fetchOptions;
+					promise = loader
+						.parse( buffer )
+						.then( res => res.scene );
+					break;
+
+				}
+
+				case 'i3dm': {
+
+					const loader = new I3DMLoader( manager );
+					loader.workingPath = workingPath;
+					loader.fetchOptions = fetchOptions;
+					promise = loader
+						.parse( buffer )
+						.then( res => res.scene );
+					break;
+
+				}
+
+				case 'cmpt': {
+
+					const loader = new CMPTLoader( manager );
+					loader.workingPath = workingPath;
+					loader.fetchOptions = fetchOptions;
+					promise = loader
+						.parse( buffer )
+						.then( res => res.scene	);
+					break;
+
+				}
+
+				// 3DTILES_content_gltf
+				case 'gltf':
+				case 'glb':
+					const loader = new GLTFExtensionLoader( manager );
+					loader.workingPath = workingPath;
+					loader.fetchOptions = fetchOptions;
+					promise = loader
+						.parse( buffer )
+						.then( res => res.scene	);
+					break;
+
+				default:
+					console.warn( `TilesRenderer: Content type "${ extension }" not supported.` );
+					promise = Promise.resolve( null );
+					break;
 
 			}
-
-			case 'pnts': {
-
-				const loader = new PNTSLoader( manager );
-				loader.workingPath = workingPath;
-				loader.fetchOptions = fetchOptions;
-				promise = loader
-					.parse( buffer )
-					.then( res => res.scene );
-				break;
-
-			}
-
-			case 'i3dm': {
-
-				const loader = new I3DMLoader( manager );
-				loader.workingPath = workingPath;
-				loader.fetchOptions = fetchOptions;
-				promise = loader
-					.parse( buffer )
-					.then( res => res.scene );
-				break;
-
-			}
-
-			case 'cmpt': {
-
-				const loader = new CMPTLoader( manager );
-				loader.workingPath = workingPath;
-				loader.fetchOptions = fetchOptions;
-				promise = loader
-					.parse( buffer )
-					.then( res => res.scene	);
-				break;
-
-			}
-
-			// 3DTILES_content_gltf
-			case 'gltf':
-			case 'glb':
-				const loader = new GLTFExtensionLoader( manager );
-				loader.workingPath = workingPath;
-				loader.fetchOptions = fetchOptions;
-				promise = loader
-					.parse( buffer )
-					.then( res => res.scene	);
-				break;
-
-			default:
-				console.warn( `TilesRenderer: Content type "${ extension }" not supported.` );
-				promise = Promise.resolve( null );
-				break;
 
 		}
-
 		return promise.then( scene => {
 
 			if ( tile._loadIndex !== loadIndex ) {

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -18,6 +18,8 @@ import {
 	convertTileTransform,
 } from './ThreeTileUtils.js';
 
+import { GLTFExtension } from '../extensions/3DTILES_content_gltf.js';
+
 const INITIAL_FRUSTUM_CULLED = Symbol( 'INITIAL_FRUSTUM_CULLED' );
 const tempMat = new Matrix4();
 const tempMat2 = new Matrix4();
@@ -104,6 +106,11 @@ export class TilesRenderer extends TilesRendererBase {
 			}
 
 		};
+
+		// TODO(extensions): I'd rather only add this if the tileset supports gltf AND gltf isn't already registered
+		// so this should likely go along with fetchRootTileset
+		// but that's in TilesRendererBase, and GLTF is threejs specific
+		this.extensions.register( () => new GLTFExtension( manager ) );
 
 	}
 

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -107,11 +107,6 @@ export class TilesRenderer extends TilesRendererBase {
 
 		};
 
-		// TODO(extensions): I'd rather only add this if the tileset supports gltf AND gltf isn't already registered
-		// so this should likely go along with fetchRootTileset
-		// but that's in TilesRendererBase, and GLTF is threejs specific
-		this.extensions.register( () => new GLTFExtension( manager ) );
-
 	}
 
 	/* Public API */
@@ -310,6 +305,9 @@ export class TilesRenderer extends TilesRendererBase {
 	/* Overriden */
 	fetchTileSet( url, ...rest ) {
 
+		const extensions = this.extensions;
+		const manager = this.manager;
+
 		const pr = super.fetchTileSet( url, ...rest );
 		pr.then( json => {
 
@@ -323,6 +321,15 @@ export class TilesRenderer extends TilesRendererBase {
 					this.onLoadTileSet( json, url );
 
 				} );
+
+			}
+
+			// check for any newly seen extensions in the loaded tileset
+			extensions.checkSupport( json, true );
+			// add gltf support if the tileset requires gltf AND gltf isn't already registered?
+			if ( extensions.requires( '3DTILES_content_gltf' ) ) {
+
+				extensions.register( () => new GLTFExtension( manager ) );
 
 			}
 

--- a/test/ExtensionSystem.test.js
+++ b/test/ExtensionSystem.test.js
@@ -1,0 +1,176 @@
+import { TILESETS } from './__fixtures__/ExtensionSystem.tilesets.js';
+import { ExtensionSystem } from '../src/extensions/ExtensionSystem.js';
+import { ExtensionBase } from '../src/extensions/ExtensionBase.js';
+import { ExtensionType } from '../src/extensions/ExtensionType.js';
+
+describe( 'ExtensionSystem', () => {
+
+	describe( '3DTILES_content_gltf', () => {
+
+		it( 'says we support 3DTILES_content_gltf by default', () => {
+
+			// change if gltf ends up removed from parseTile
+			const extensions = new ExtensionSystem();
+			expect( extensions.has( '3DTILES_content_gltf' ) ).toEqual( true );
+
+		} );
+
+		it( 'useTileset gltf expected', () => {
+
+			const tileset = TILESETS.gltf;
+			const extensions = new ExtensionSystem().useTileset( tileset );
+			expect( extensions.has( '3DTILES_content_gltf' ) ).toEqual( true );
+
+		} );
+
+	} );
+
+	describe( 'VENDOR_required_extension', () => {
+
+		it( 'requires, register, has', () => {
+
+			const tileset = TILESETS.vendorRequired;
+			const extName = TILESETS.EXT_NAMES.VENDOR_required_extension;
+			const extensions = new ExtensionSystem().useTileset( tileset );
+			expect( extensions.has( extName ) ).toEqual( false );
+			expect( extensions.requires( extName ) ).toEqual( true );
+
+			// initial registration is active, valid, included in system, and no longer required
+			const registration = extensions.register( () => new VendorRequiredTileExtension() );
+			expect( registration.active() ).toEqual( true );
+			expect( extensions.has( extName ) ).toEqual( true );
+			expect( extensions.requires( extName ) ).toEqual( false );
+
+			// unregistered, back to previous
+			registration.cancel();
+			expect( registration.active() ).toEqual( false );
+			expect( extensions.has( extName ) ).toEqual( false );
+			expect( extensions.requires( extName ) ).toEqual( true );
+
+		} );
+
+		it( 'can access tileset extension data', () => {
+
+			const tileset = TILESETS.vendorRequired;
+			const extensions = new ExtensionSystem().useTileset( tileset );
+			extensions.register( () => new VendorRequiredTileExtension() );
+
+			const response = extensions.useFunction( 'parse', tileset.root );
+			expect( response ).not.toBeNull();
+			expect( response.tileset ).not.toEqual( {} );
+			expect( response.tile ).toBeNull();
+			expect( response.tileset.details ).toEqual( [ "required", "content" ] );
+
+		} );
+
+	} );
+
+	describe( 'VENDOR_optional_extension', () => {
+
+		it( 'requires, register, has', () => {
+
+			const tileset = TILESETS.vendorOptionalAndRequired;
+			const extName = TILESETS.EXT_NAMES.VENDOR_optional_extension;
+			const extensions = new ExtensionSystem().useTileset( tileset );
+			expect( extensions.has( extName ) ).toEqual( false );
+			expect( extensions.requires( extName ) ).toEqual( false );
+
+			// initial registration is active, valid, included in system, and no longer required
+			const registration = extensions.register( () => new VendorOptionalContentExtension() );
+			expect( registration.active() ).toEqual( true );
+			expect( extensions.has( extName ) ).toEqual( true );
+			expect( extensions.requires( extName ) ).toEqual( false );
+
+			// unregistered, back to previous
+			registration.cancel();
+			expect( registration.active() ).toEqual( false );
+			expect( extensions.has( extName ) ).toEqual( false );
+			expect( extensions.requires( extName ) ).toEqual( false );
+
+		} );
+
+	} );
+
+	describe( 'requires', () => {
+
+		it( 'optional and required extensions in the full tileset', () => {
+
+			const tileset = TILESETS.allTheThings;
+			const extensions = new ExtensionSystem().useTileset( tileset );
+
+			let extName = 'VENDOR_required_extension';
+			expect( extensions.has( extName ) ).toEqual( false );
+			expect( extensions.requires( extName ) ).toEqual( true );
+
+			extName = 'VENDOR_optional_extension';
+			expect( extensions.has( extName ) ).toEqual( false );
+			expect( extensions.requires( extName ) ).toEqual( false );
+
+			extName = '3DTILES_content_gltf';
+			expect( extensions.has( extName ) ).toEqual( true );
+			expect( extensions.requires( extName ) ).toEqual( false );
+
+		} );
+
+	} );
+
+} );
+
+describe( 'ExtensionBase', () => {
+
+	it( 'requires a valid data type', () => {
+
+		expect( () => new InvalidExtension() ).toThrow();
+		expect( () => new VendorRequiredTileExtension() ).not.toThrow();
+		expect( () => new VendorOptionalContentExtension() ).not.toThrow();
+
+	} );
+
+} );
+
+/** Types of mock extensions used in the test */
+class InvalidExtension extends ExtensionBase {
+
+	constructor() {
+
+		super( 'invalid_extension_type', 'extension_invalid' );
+
+	}
+
+}
+
+class VendorRequiredTileExtension extends ExtensionBase {
+
+	constructor() {
+
+		super( ExtensionType.TILE, TILESETS.EXT_NAMES.VENDOR_required_extension );
+
+	}
+
+	parse( perTileData ) {
+
+		const tileset = this.data;
+		const tile = perTileData;
+		return Object.assign( {}, { tileset }, { tile } );
+
+	}
+
+}
+
+class VendorOptionalContentExtension extends ExtensionBase {
+
+	constructor() {
+
+		super( ExtensionType.CONTENT, TILESETS.EXT_NAMES.VENDOR_optional_extension );
+
+	}
+
+	fetch( perTileData ) {
+
+		const tileset = this.data;
+		const tile = perTileData;
+		return Object.assign( {}, { tileset }, { tile } );
+
+	}
+
+}

--- a/test/ExtensionSystem.test.js
+++ b/test/ExtensionSystem.test.js
@@ -89,6 +89,27 @@ describe( 'ExtensionSystem', () => {
 
 		} );
 
+		it( 'useFunction gets tile.content extension data', () => {
+
+			const tileset = TILESETS.vendorOptional;
+			const extName = TILESETS.EXT_NAMES.VENDOR_optional_extension;
+			const extensions = new ExtensionSystem().useTileset( tileset );
+			expect( extensions.has( extName ) ).toEqual( false );
+			expect( extensions.requires( extName ) ).toEqual( false );
+			extensions.register( () => new VendorOptionalContentExtension() );
+
+			// this extension only implements fetch, so parse is a nop
+			let response = extensions.useFunction( 'parse', tileset.root.children[ 0 ] );
+			expect( response ).toBeNull();
+
+			// fetch gets data from the extension blobs
+			response = extensions.useFunction( 'fetch', tileset.root.children[ 0 ] );
+			expect( response ).not.toBeNull();
+			expect( response.tileset.details ).toEqual( [ 'some', 'tileset', 'wide', 'content' ] );
+			expect( response.tile.details ).toEqual( 'from tile.content.extensions.VENDOR_optional_extension' );
+
+		} );
+
 	} );
 
 	describe( 'requires', () => {

--- a/test/__fixtures__/ExtensionSystem.tilesets.js
+++ b/test/__fixtures__/ExtensionSystem.tilesets.js
@@ -1,0 +1,102 @@
+import { merge } from './utilities.js';
+
+function makeTileset( contentFileExt, mergedTilesetContent ) {
+
+	const base = {
+		"asset": {
+			"version": "1.0"
+		},
+		"geometricError": 1.0,
+		"root": {
+			"content": {
+				"uri": `root.${contentFileExt}`
+			},
+			"boundingVolume": {
+				"box": [ 68, - 22, 4, 74, 0, 0, 0, - 29, 0, 0, 0, 6 ]
+			},
+			"geometricError": 1.0,
+			"refine": "REPLACE",
+			"children": [
+				{
+					"content": {
+						"uri": `tile.${contentFileExt}`
+					},
+					"boundingVolume": {
+						"box": [ 68, - 22, 4, 74, 0, 0, 0, - 29, 0, 0, 0, 6 ]
+					},
+					"geometricError": 0.5,
+					"refine": "REPLACE",
+					"children": [ ]
+				}
+			]
+		}
+	};
+
+	// note, concats any arrays in both objects, so children in merged content are additive
+	return merge( [ base, mergedTilesetContent ] );
+
+}
+
+const gltfExtensionContent = {
+	"extensionsUsed": [
+		"3DTILES_content_gltf",
+	],
+	"extensionsRequired": [
+		"3DTILES_content_gltf",
+	],
+	"extensions": {
+		"3DTILES_content_gltf": {
+			"extensionsUsed": [
+				"KHR_draco_mesh_compression",
+				"KHR_texture_basisu",
+			],
+			"extensionsRequired": [
+				"KHR_draco_mesh_compression",
+				"KHR_texture_basisu",
+			]
+		},
+	},
+};
+
+const vendorRequiredContent = {
+	"extensionsUsed": [
+		"VENDOR_required_extension"
+	],
+	"extensionsRequired": [
+		"VENDOR_required_extension"
+	],
+	"extensions": {
+		"VENDOR_required_extension": {
+			"details": [ "required", "content" ]
+		}
+	},
+};
+
+const vendorOptionalContent = {
+	"extensionsUsed": [
+		"VENDOR_optional_extension",
+	],
+	"extensions": {
+		"VENDOR_optional_extension": {
+			"details": [ "some", "tileset", "wide", "content" ]
+		},
+	},
+};
+
+export const TILESETS = {
+
+	EXT_NAMES: {
+		"VENDOR_required_extension": "VENDOR_required_extension",
+		"VENDOR_optional_extension": "VENDOR_optional_extension",
+		"3DTILES_content_gltf": "3DTILES_content_gltf",
+	},
+
+	base: makeTileset( 'b3dm', {} ),
+	gltf: makeTileset( 'gltf', gltfExtensionContent ),
+	vendorOptional: makeTileset( 'glb', vendorOptionalContent ),
+	vendorRequired: makeTileset( 'pnts', vendorRequiredContent ),
+	vendorOptionalAndRequired: makeTileset( 'b3dm', merge( [ vendorRequiredContent, vendorOptionalContent ] ) ),
+	vendorRequiredAndgltf: makeTileset( 'gltf', merge( [ vendorRequiredContent, gltfExtensionContent ] ) ),
+	allTheThings: makeTileset( 'glb', merge( [ gltfExtensionContent, vendorRequiredContent, vendorOptionalContent ] ) ),
+
+};

--- a/test/__fixtures__/ExtensionSystem.tilesets.js
+++ b/test/__fixtures__/ExtensionSystem.tilesets.js
@@ -81,6 +81,26 @@ const vendorOptionalContent = {
 			"details": [ "some", "tileset", "wide", "content" ]
 		},
 	},
+	"root": {
+		"children": [
+			{
+				"content": {
+					"uri": `optionalExtension.glb`,
+					"extensions": {
+						"VENDOR_optional_extension": {
+							"details": "from tile.content.extensions.VENDOR_optional_extension"
+						},
+					}
+				},
+				"boundingVolume": {
+					"box": [ 68, - 22, 4, 74, 0, 0, 0, - 29, 0, 0, 0, 6 ]
+				},
+				"geometricError": 0.5,
+				"refine": "REPLACE",
+				"children": [ ]
+			}
+		]
+	}
 };
 
 export const TILESETS = {

--- a/test/__fixtures__/utilities.js
+++ b/test/__fixtures__/utilities.js
@@ -1,0 +1,80 @@
+export function clone( src ) {
+
+	const dst = {};
+
+	for ( const u in src ) {
+
+		if ( Array.isArray( src[ u ] ) ) {
+
+			dst[ u ] = [];
+
+		} else if ( typeof src[ u ] === 'object' ) {
+
+			dst[ u ] = {};
+
+		} else {
+
+			dst[ u ] = src[ u ];
+
+		}
+
+		for ( const p in src[ u ] ) {
+
+			const property = src[ u ][ p ];
+
+			if ( Array.isArray( property ) ) {
+
+				dst[ u ][ p ] = property.slice();
+
+			} else if ( property !== undefined ) {
+
+				dst[ u ][ p ] = property;
+
+			}
+
+		}
+
+	}
+
+	return dst;
+
+}
+
+export function merge( objects ) {
+
+	const merged = {};
+
+	for ( let u = 0; u < objects.length; u ++ ) {
+
+		const tmp = clone( objects[ u ] );
+
+		for ( const p in tmp ) {
+
+			// eh, assumes types are consistant, and that we want to always merge arrays
+			if ( Array.isArray( tmp[ p ] ) ) {
+
+				const arr = merged[ p ];
+
+				if ( Array.isArray( arr ) ) {
+
+					merged[ p ] = tmp[ p ].slice().concat( arr );
+
+				} else {
+
+					merged[ p ] = tmp[ p ].slice();
+
+				}
+
+			} else {
+
+				merged[ p ] = tmp[ p ];
+
+			}
+
+		}
+
+	}
+
+	return merged;
+
+}


### PR DESCRIPTION
[extensions] - Initial extension system attempt
- Let's see if it blends while implementing a few extensions?!
- works for both my custom internal extensions, the prototype-hackery, and the one to be kept (!)
- basic ExtensionSystem based [3DTILES_content_gltf](https://github.com/CesiumGS/3d-tiles/tree/main/extensions/3DTILES_content_gltf) extension which can replace hard coded .gltf/glb, and be shared across multiple parse areas (cmpt + main parseTile)
  - downside, it breaks from the LoaderBase parts / duplicates the previous commits, so one should be chosen before this merges?

Extendability: These are the extensions that I have some amount of interest in using, and I think this should cover some of these cases.
- It should work for [3DTILES_multiple_contents](https://github.com/CesiumGS/3d-tiles/tree/main/extensions/3DTILES_multiple_contents) using ExtensionType.TILE
- It should work for per tile metadata using [3DTILES_metadata](https://github.com/CesiumGS/3d-tiles/tree/main/extensions/3DTILES_metadata#tile-properties)

Other extensions may require further system change?