### PR TITLE
DebugTilesRenderer: Use an "unlit" setting

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -66,6 +66,7 @@ const params = {
 	displaySphereBounds: false,
 	displayRegionBounds: false,
 	colorMode: urlParams.get( 'colorMode' ) in DebugTilesPlugin.ColorModes ? DebugTilesPlugin.ColorModes[ urlParams.get( 'colorMode' ) ] : DebugTilesPlugin.ColorModes.NONE,
+	unlit: Boolean( urlParams.get( 'unlit' ) ),
 	showThirdPerson: false,
 	showSecondView: false,
 	reload: reinstantiateTiles,
@@ -267,6 +268,7 @@ function init() {
 	debug.add( params, 'displaySphereBounds' );
 	debug.add( params, 'displayRegionBounds' );
 	debug.add( params, 'colorMode', DebugTilesPlugin.ColorModes );
+	debug.add( params, 'unlit' );
 	debug.open();
 
 	const exampleOptions = gui.addFolder( 'Example Options' );
@@ -466,6 +468,7 @@ function animate() {
 	plugin.displaySphereBounds = params.displaySphereBounds;
 	plugin.displayRegionBounds = params.displayRegionBounds;
 	plugin.colorMode = parseFloat( params.colorMode );
+	plugin.unlit = params.unlit;
 
 	if ( params.orthographic ) {
 

--- a/src/plugins/three/DebugTilesPlugin.d.ts
+++ b/src/plugins/three/DebugTilesPlugin.d.ts
@@ -12,7 +12,6 @@ export const IS_LEAF : ColorMode;
 export const RANDOM_COLOR : ColorMode;
 export const RANDOM_NODE_COLOR: ColorMode;
 export const CUSTOM_COLOR: ColorMode;
-export const UNLIT: ColorMode;
 export class DebugTilesPlugin {
 
 	static ColorModes: typeof ColorMode;
@@ -23,6 +22,7 @@ export class DebugTilesPlugin {
 	displaySphereBounds : boolean;
 	displayRegionBounds : boolean;
 	colorMode : ColorMode;
+	unlit: boolean;
 	maxDebugDepth : number;
 	maxDebugDistance : number;
 	maxDebugError : number;


### PR DESCRIPTION
Adjusts https://github.com/NASA-AMMOS/3DTilesRendererJS/pull/1159 to use an "unlit" flag for DebugTilesRenderer. The "colorMode" and "unlit" fields set a "materialNeedsUpdate" flag which is then used to trigger material changes on update. The "unlit" flag can be triggered via search param in the index.js example.